### PR TITLE
fix(fuzzyClock): fix sundays showing up as 'middle of week'

### DIFF
--- a/redesign.user.js
+++ b/redesign.user.js
@@ -4569,7 +4569,7 @@ if (getSetting('clock.fuzzyClock')) {
                         const weekString =
                             dayOfWeek === 1 ?
                                 0 // Monday
-                            : 2 <= dayOfWeek && dayOfWeek <= 3 ?
+                            : dayOfWeek >= 2 && dayOfWeek <= 3 ?
                                 1 // Tuesday, Wednesday
                             : dayOfWeek <= 5 ?
                                 2 // Thursday, Friday

--- a/redesign.user.js
+++ b/redesign.user.js
@@ -4569,7 +4569,7 @@ if (getSetting('clock.fuzzyClock')) {
                         const weekString =
                             dayOfWeek === 1 ?
                                 0 // Monday
-                            : dayOfWeek <= 3 ?
+                            : 2 <= dayOfWeek && dayOfWeek <= 3 ?
                                 1 // Tuesday, Wednesday
                             : dayOfWeek <= 5 ?
                                 2 // Thursday, Friday


### PR DESCRIPTION
# Fix

* **fuzzyClock:** fix sundays showing up as 'middle of week' ([6aa0922](https://github.com/jxn-30/better-moodle/commit/6aa0922db0057570128a37948ab415e2ad34a77f))