### PR TITLE
feat(settings): add option to highlight new settings (#152)

### DIFF
--- a/redesign.user.js
+++ b/redesign.user.js
@@ -5060,8 +5060,7 @@ ready(() => {
             settingsBtnNewTooltip = new Tooltip(settingsIcon, {
                 trigger: 'manual',
                 title: $t('new'),
-                template:
-                    '<div class="tooltip" role="tooltip"><div class="arrow"></div><div class="tooltip-inner badge bg-success text-uppercase"></div></div>',
+                template: `<div class="tooltip" role="tooltip"><div class="arrow"></div><div class="tooltip-inner badge bg-success text-uppercase ${newSettingBadgeClass}"></div></div>`,
             });
             settingsBtnNewTooltip.show();
         });

--- a/redesign.user.js
+++ b/redesign.user.js
@@ -2540,7 +2540,7 @@ if (seenSettings.size === 0) {
 }
 /** @type {Set<string>} */
 const unseenSettings =
-    allSettingsIds.difference?.(seenSettings) ?? // New Set methods are a stage 2 proposal and do have limited availability: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/difference
+    allSettingsIds.difference?.(seenSettings) ?? // New Set methods are a stage 3 proposal and do have limited availability: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/difference
     new Set(
         Array.from(allSettingsIds.values()).filter(id => !seenSettings.has(id))
     );

--- a/redesign.user.js
+++ b/redesign.user.js
@@ -230,6 +230,11 @@ Viele Grüße
                     name: 'Neue Einstellungen hervorheben',
                     description:
                         'Informiert, welche Einstellungen neu sind, wenn es neue Einstellungen gibt.',
+                    navbar: {
+                        name: 'Hinweis zu neuen Einstellungen auf dem Einstellungs-Knopf',
+                        description:
+                            'Zeigt ein schickes Tooltip am Einstellungs-Knopf in der Navigationsleiste an, wenn es neue Einstellungen gibt.',
+                    },
                 },
                 fullwidth: {
                     name: 'Volle Breite',
@@ -641,6 +646,16 @@ Best regards
                     name: 'Notification for Better-Moodle updates',
                     description:
                         'Displays a small red dot by the cogs in the navigation bar when there is an update for Better-Moodle.',
+                },
+                highlightNewSettings: {
+                    name: 'Highlight new settings',
+                    description:
+                        'Highlights which settings are new, if there are any new settings.',
+                    navbar: {
+                        name: 'Note for new settings on settings button',
+                        description:
+                            'Shows a nice tooltip informing about new settings on the settings button in navbar if there are any unseen settings.',
+                    },
                 },
                 fullwidth: {
                     name: 'Full width',

--- a/redesign.user.js
+++ b/redesign.user.js
@@ -2541,9 +2541,7 @@ if (seenSettings.size === 0) {
 const unseenSettings =
     allSettingsIds.difference?.(seenSettings) ?? // New Set methods are a stage 2 proposal and do have limited availability: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/difference
     new Set(
-        ...Array.from(allSettingsIds.values()).filter(
-            id => !seenSettings.has(id)
-        )
+        Array.from(allSettingsIds.values()).filter(id => !seenSettings.has(id))
     );
 /** @type {Map<string, number>} */
 const unseenSettingsGroups = new Map();

--- a/redesign.user.js
+++ b/redesign.user.js
@@ -876,6 +876,8 @@ const getSettingKey = id => PREFIX(`settings.${id}`);
 const getSetting = (id, inputValue = false) =>
     inputValue ? settingsById[id].inputValue : settingsById[id].value;
 
+const IS_NEW_INSTALLATION = GM_listValues().length === 0;
+
 const MyCoursesFilterSyncChangeKey = PREFIX('myCourses.filterSyncChange');
 
 /**
@@ -2613,9 +2615,12 @@ if (seenSettings.size === 0) {
     markAllSettingsAsSeen();
 
     // okay, we want to show those two as NEW to give users a hint for new settings and that there are settings
-    seenSettings.delete('general.highlightNewSettings');
-    seenSettings.delete('general.highlightNewSettings.navbar');
-    storeSeenSettings(); // need to store again
+    // but only if this is not a new installation.
+    if (!IS_NEW_INSTALLATION) {
+        seenSettings.delete('general.highlightNewSettings');
+        seenSettings.delete('general.highlightNewSettings.navbar');
+        storeSeenSettings(); // need to store again
+    }
 }
 /** @type {Set<string>} */
 const unseenSettings =
@@ -5057,8 +5062,9 @@ ready(() => {
         .querySelector('#usernavigation .usermenu-container')
         ?.before(settingsBtnWrapper);
     if (
-        unseenSettings.size &&
-        getSetting('general.highlightNewSettings.navbar')
+        (unseenSettings.size &&
+            getSetting('general.highlightNewSettings.navbar')) ||
+        IS_NEW_INSTALLATION
     ) {
         require(['theme_boost/bootstrap/tooltip'], Tooltip => {
             settingsIcon.title = $t('new').toString(); // otherwise it for some reason would use the original title although another title has been explicitely set

--- a/redesign.user.js
+++ b/redesign.user.js
@@ -2514,9 +2514,6 @@ const storeSeenSettings = () =>
     GM_setValue(SEEN_SETTINGS_KEY, Array.from(seenSettings));
 const markAllSettingsAsSeen = () => {
     allSettingsIds.forEach(id => seenSettings.add(id));
-    document
-        .querySelectorAll('.new-settings-badge')
-        ?.forEach(el => el.remove());
     settingsBtnNewTooltip?.dispose();
 
     settingsBtnNewTooltip = null;

--- a/redesign.user.js
+++ b/redesign.user.js
@@ -2597,12 +2597,13 @@ form .fitem label .${newSettingBadgeClass} {
         display: inline-block;
         content: " ";
         position: absolute;
-        background: linear-gradient(to top, gold 50%, white 100%);
          --width: 10ch;
         width: var(--width);
         height: calc(var(--width) * 18 / 11);
-        /* stolen from https://css-shape.com/sparkle/ */
-        mask: radial-gradient(#0000 71%, #000 72%) 10000% 10000%/99.5% 99.5%;
+        /* this is a self designed sparkle as SVG :) */
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1100 1800'%3E%3Cpath fill='gold' d='M 550 0 C 550 720 660 900 1100 900 C 660 900 550 1080 550 1800 C 550 1080 440 900 0 900 C 440 900 550 720 550 0'/%3E%3C/svg%3E");
+        background-size: 100%;
+        background-repeat: no-repeat;
         transform: translate(-50%, -50%);
         transform-origin: top left;
         top: 0;

--- a/redesign.user.js
+++ b/redesign.user.js
@@ -2519,6 +2519,8 @@ const markAllSettingsAsSeen = () => {
         ?.forEach(el => el.remove());
     settingsBtnNewTooltip?.dispose();
 
+    settingsBtnNewTooltip = null;
+
     storeSeenSettings();
 };
 GM_addStyle(`
@@ -5036,8 +5038,8 @@ ready(() => {
                 if (settingsBtnNewTooltip) {
                     settingsBtnNewTooltip.hide();
                     // now show and hide based on hovering / focusing settings btn (there doesn't seem to be a native way to do so)
-                    const show = () => settingsBtnNewTooltip.show();
-                    const hide = () => settingsBtnNewTooltip.hide();
+                    const show = () => settingsBtnNewTooltip?.show();
+                    const hide = () => settingsBtnNewTooltip?.hide();
                     settingsBtn.addEventListener('mouseenter', show);
                     settingsBtn.addEventListener('focusin', show);
                     settingsBtn.addEventListener('mouseleave', hide);

--- a/redesign.user.js
+++ b/redesign.user.js
@@ -2593,23 +2593,11 @@ form .fitem label .${newSettingBadgeClass} {
         top: 4%;
         left: 14%
     }
-    32% {
-        top: 4%;
-        left: 14%
-    }
     33% {
         top: 85%;
         left: 51%;
     }
-    65% {
-        top: 85%;
-        left: 51%;
-    }
     66% {
-        top: 32%;
-        left: 87%;
-    }
-    100% {
         top: 32%;
         left: 87%;
     }

--- a/redesign.user.js
+++ b/redesign.user.js
@@ -2507,6 +2507,7 @@ const settingsById = Object.fromEntries(
 
 const allSettingsIds = new Set(Object.keys(settingsById));
 const SEEN_SETTINGS_KEY = PREFIX('seen-settings');
+const newSettingBadgeClass = PREFIX('new-setting-badge');
 let settingsBtnNewTooltip;
 /** @type {Set<string>} */
 const seenSettings = new Set(GM_getValue(SEEN_SETTINGS_KEY, []));
@@ -2522,10 +2523,10 @@ const markAllSettingsAsSeen = () => {
 };
 GM_addStyle(`
 /* add a small margin for "NEW!"-Badges in settings */
-form fieldset h3 .new-setting-badge {
+form fieldset h3 .${newSettingBadgeClass} {
     margin-left: 1ch;
 }
-form .fitem label .new-setting-badge {
+form .fitem label .${newSettingBadgeClass} {
     margin-right: 1ch;
 }
 `);
@@ -4818,7 +4819,7 @@ ready(() => {
                 'badge',
                 'badge-success',
                 'text-uppercase',
-                'new-setting-badge'
+                newSettingBadgeClass
             );
             newBadge.textContent = $t('new').toString();
             newBadge.dataset.group = name;
@@ -4883,7 +4884,7 @@ ready(() => {
                     'badge-success',
                     'text-uppercase',
                     'd-inline',
-                    'new-setting-badge'
+                    newSettingBadgeClass
                 );
                 newBadge.textContent = $t('new').toString();
                 newBadge.dataset.setting = setting.id;

--- a/redesign.user.js
+++ b/redesign.user.js
@@ -2402,7 +2402,12 @@ const SETTINGS = [
         ...Object.keys(TRANSLATIONS),
     ]),
     new BooleanSetting('general.highlightNewSettings', true),
-    new BooleanSetting('general.highlightNewSettings.navbar', true),
+    new BooleanSetting(
+        'general.highlightNewSettings.navbar',
+        true
+    ).setDisabledFn(
+        settings => !settings['general.highlightNewSettings'].inputValue
+    ),
     new BooleanSetting('general.fullwidth', true),
     new BooleanSetting('general.externalLinks', true),
     new BooleanSetting('general.truncatedTexts', true),

--- a/redesign.user.js
+++ b/redesign.user.js
@@ -2509,6 +2509,7 @@ const settingsById = Object.fromEntries(
 
 const allSettingsIds = new Set(Object.keys(settingsById));
 const SEEN_SETTINGS_KEY = PREFIX('seen-settings');
+const EVER_OPENED_SETTINGS_KEY = PREFIX('ever-opened-settings');
 const newSettingBadgeClass = PREFIX('new-setting-badge');
 let settingsBtnNewTooltip;
 // these are the settings that existed before "highlight new settings" was introduced
@@ -5094,7 +5095,7 @@ ready(() => {
     if (
         (unseenSettings.size &&
             getSetting('general.highlightNewSettings.navbar')) ||
-        IS_NEW_INSTALLATION
+        !GM_getValue(EVER_OPENED_SETTINGS_KEY, false)
     ) {
         require(['theme_boost/bootstrap/tooltip'], Tooltip => {
             settingsIcon.title = $t('new').toString(); // otherwise it for some reason would use the original title although another title has been explicitely set
@@ -5148,6 +5149,7 @@ ready(() => {
 
             // open the modal on click onto the settings button
             settingsBtnWrapper.addEventListener('click', () => {
+                GM_setValue(EVER_OPENED_SETTINGS_KEY, true);
                 updateCheck().then();
                 if (settingsBtnNewTooltip) {
                     settingsBtnNewTooltip.hide();

--- a/redesign.user.js
+++ b/redesign.user.js
@@ -2511,8 +2511,46 @@ const allSettingsIds = new Set(Object.keys(settingsById));
 const SEEN_SETTINGS_KEY = PREFIX('seen-settings');
 const newSettingBadgeClass = PREFIX('new-setting-badge');
 let settingsBtnNewTooltip;
+// these are the settings that existed before "highlight new settings" was introduced
+const existingSettings = new Set([
+    'general.updateNotification',
+    'general.language',
+    'general.fullwidth',
+    'general.externalLinks',
+    'general.truncatedTexts',
+    'general.bookmarkManager',
+    'general.noDownload',
+    'general.eventAdvertisements',
+    'general.christmasCountdown',
+    'general.speiseplan',
+    'general.googlyEyes',
+    'general.semesterzeiten',
+    'darkmode.mode',
+    'darkmode.brightness',
+    'darkmode.contrast',
+    'darkmode.grayscale',
+    'darkmode.sepia',
+    'dashboard.~layoutPlaceholder',
+    'dashboard.courseListFilter',
+    'dashboard.courseListFavouritesAtTop',
+    'myCourses.boxesPerRow',
+    'myCourses.navbarDropdown',
+    'myCourses.navbarDropdownFilter',
+    'myCourses.navbarDropdownFavouritesAtTop',
+    'courses.grades',
+    'courses.gradesNewTab',
+    'courses.collapseAll',
+    'courses.imgMaxWidth',
+    'courses.imageZoom',
+    'courses.hideSelfEnrolHint',
+    'clock.clock',
+    'clock.clock.seconds',
+    'clock.fuzzyClock',
+    'clock.fuzzyClock.fuzziness',
+    'messages.sendHotkey',
+]);
 /** @type {Set<string>} */
-const seenSettings = new Set(GM_getValue(SEEN_SETTINGS_KEY, []));
+const seenSettings = new Set(GM_getValue(SEEN_SETTINGS_KEY, existingSettings));
 const storeSeenSettings = () =>
     GM_setValue(SEEN_SETTINGS_KEY, Array.from(seenSettings));
 const markAllSettingsAsSeen = () => {
@@ -2610,18 +2648,8 @@ form .fitem label .${newSettingBadgeClass} {
     }
 }
 `);
-// let's add all current settings in first place
-if (seenSettings.size === 0) {
-    markAllSettingsAsSeen();
-
-    // okay, we want to show those two as NEW to give users a hint for new settings and that there are settings
-    // but only if this is not a new installation.
-    if (!IS_NEW_INSTALLATION) {
-        seenSettings.delete('general.highlightNewSettings');
-        seenSettings.delete('general.highlightNewSettings.navbar');
-        storeSeenSettings(); // need to store again
-    }
-}
+// if this is a new installation, mark all settings as seen as we don't want to show the "NEW!"-badge on every single setting
+if (IS_NEW_INSTALLATION) markAllSettingsAsSeen();
 /** @type {Set<string>} */
 const unseenSettings =
     allSettingsIds.difference?.(seenSettings) ?? // New Set methods are a stage 3 proposal and do have limited availability: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/difference

--- a/redesign.user.js
+++ b/redesign.user.js
@@ -4873,7 +4873,7 @@ ready(() => {
                 'pt-0'
             );
             const label = document.createElement('label');
-            label.classList.add('d-inline', 'word-break-all');
+            label.classList.add('d-inline', 'word-break');
             label.textContent = setting.title;
             setting.setLabel(label);
 

--- a/redesign.user.js
+++ b/redesign.user.js
@@ -5230,6 +5230,10 @@ ready(() => {
                         )) {
                             const bottom = badge.getBoundingClientRect().bottom;
                             if (bottom > floatingBadgeBottom) {
+                                badge
+                                    .closest('.ftoggler')
+                                    ?.querySelector('a.fheader.collapsed')
+                                    ?.click();
                                 badge.scrollIntoView({
                                     block: 'center',
                                     behavior: 'smooth',
@@ -5241,15 +5245,14 @@ ready(() => {
                     });
 
                     if (lastNewSettingsBadge) {
+                        const debouncedUpdate = debounce(
+                            updateFloatingNewSettingsBadgeStyle,
+                            25
+                        );
                         modal
                             .getBody()[0]
-                            .addEventListener(
-                                'scroll',
-                                debounce(
-                                    updateFloatingNewSettingsBadgeStyle,
-                                    10
-                                )
-                            );
+                            .addEventListener('scroll', debouncedUpdate);
+                        new ResizeObserver(debouncedUpdate).observe(form);
                     }
 
                     modal.getBody()[0].append(floatingNewSettingsBadge);

--- a/redesign.user.js
+++ b/redesign.user.js
@@ -2578,6 +2578,7 @@ form .fitem label .${newSettingBadgeClass} {
 /* the \`New!\`-Tooltip of settings btn needs to have a special z-index */
 .tooltip:has(.${newSettingBadgeClass}) {
     z-index: 1035;
+    cursor: pointer;
 }
 
 /* nice effects on the \`New!\`-Badge, but only if user allows animations */
@@ -5101,6 +5102,9 @@ ready(() => {
                 title: $t('new'),
                 template: `<div class="tooltip" role="tooltip"><div class="arrow"></div><div class="tooltip-inner badge bg-success text-uppercase ${newSettingBadgeClass}"></div></div>`,
             });
+            settingsBtnNewTooltip
+                .getTipElement()
+                .addEventListener('click', () => settingsBtn.click());
             settingsBtnNewTooltip.show();
         });
     }

--- a/redesign.user.js
+++ b/redesign.user.js
@@ -2536,6 +2536,7 @@ if (seenSettings.size === 0) {
     // okay, we want to show those two as NEW to give users a hint for new settings and that there are settings
     seenSettings.delete('general.highlightNewSettings');
     seenSettings.delete('general.highlightNewSettings.navbar');
+    storeSeenSettings(); // need to store again
 }
 /** @type {Set<string>} */
 const unseenSettings =

--- a/redesign.user.js
+++ b/redesign.user.js
@@ -5106,6 +5106,7 @@ ready(() => {
                 .getTipElement()
                 .addEventListener('click', () => settingsBtn.click());
             settingsBtnNewTooltip.show();
+            settingsBtnNewTooltip.update();
         });
     }
 
@@ -5150,7 +5151,10 @@ ready(() => {
                 if (settingsBtnNewTooltip) {
                     settingsBtnNewTooltip.hide();
                     // now show and hide based on hovering / focusing settings btn (there doesn't seem to be a native way to do so)
-                    const show = () => settingsBtnNewTooltip?.show();
+                    const show = () => {
+                        settingsBtnNewTooltip?.show();
+                        settingsBtnNewTooltip?.update();
+                    };
                     const hide = () => settingsBtnNewTooltip?.hide();
                     settingsBtn.addEventListener('mouseenter', show);
                     settingsBtn.addEventListener('focusin', show);

--- a/redesign.user.js
+++ b/redesign.user.js
@@ -2521,6 +2521,11 @@ const markAllSettingsAsSeen = () => {
 
     storeSeenSettings();
 };
+const newSettingBadgeAnimations = {
+    sparkling: PREFIX('new-setting-badge-sparkling'),
+    sparklePositions: PREFIX('new-setting-badge-sparkle-positions'),
+    shining: PREFIX('new-setting-badge-shining'),
+};
 GM_addStyle(`
 /* add a small margin for "NEW!"-Badges in settings */
 form fieldset h3 .${newSettingBadgeClass} {
@@ -2528,6 +2533,86 @@ form fieldset h3 .${newSettingBadgeClass} {
 }
 form .fitem label .${newSettingBadgeClass} {
     margin-right: 1ch;
+}
+
+/* nice effects on the \`New!\`-Badge, but only if user allows animations */
+@media (prefers-reduced-motion: no-preference) {
+    .${newSettingBadgeClass} {
+        position: relative;    
+        /* add a shining effect */
+        background-image: linear-gradient(-75deg, transparent 0%, rgba(255, 255, 255, 75%) 15%, transparent 30%, transparent 100%);
+        animation: ${newSettingBadgeAnimations.shining} 5s ease-in-out infinite;
+        background-size: 200%;
+        background-repeat: no-repeat
+    }
+    
+    /* add fancy sparkles ✨ to the \`New!\`-Badge */
+    .${newSettingBadgeClass}::before {
+        display: inline-block;
+        content: " ";
+        position: absolute;
+        background: linear-gradient(to top, gold 50%, white 100%);
+        --height: 1lh;
+        height: var(--height);
+        width: calc(var(--height) * 11 / 18);
+        /* stolen from https://css-shape.com/sparkle/ */
+        mask: radial-gradient(#0000 71%, #000 72%) 10000% 10000%/99.5% 99.5%;
+        transform: translate(-50%, -50%);
+        transform-origin: top left;
+        top: 0;
+        left: 0;
+        animation:
+            ${newSettingBadgeAnimations.sparkling} 1s ease-in-out infinite alternate,
+            ${newSettingBadgeAnimations.sparklePositions} 6s step-start infinite;
+    }
+}
+@keyframes ${newSettingBadgeAnimations.shining} {
+    0% {
+        background-position: 200% 0;
+    }
+    20% {
+        background-position: 0 0;
+    }
+    100% {
+        background-position: 0 0;
+    }
+}
+@keyframes ${newSettingBadgeAnimations.sparkling} {
+    0% { /* 1s => 0 ms, 2000ms */
+        scale: 0;
+    }
+    10% { /* 1s => 100ms, 1900ms */
+        scale: 0;
+    }
+    100% { /* 1s => 1000ms */
+        scale: 1;
+    }
+}
+@keyframes ${newSettingBadgeAnimations.sparklePositions} {
+    0% {
+        top: 4%;
+        left: 14%
+    }
+    32% {
+        top: 4%;
+        left: 14%
+    }
+    33% {
+        top: 85%;
+        left: 51%;
+    }
+    65% {
+        top: 85%;
+        left: 51%;
+    }
+    66% {
+        top: 32%;
+        left: 87%;
+    }
+    100% {
+        top: 32%;
+        left: 87%;
+    }
 }
 `);
 // let's add all current settings in first place

--- a/redesign.user.js
+++ b/redesign.user.js
@@ -2535,6 +2535,11 @@ form .fitem label .${newSettingBadgeClass} {
     margin-right: 1ch;
 }
 
+/* the \`New!\`-Tooltip of settings btn needs to have a special z-index */
+.tooltip:has(.${newSettingBadgeClass}) {
+    z-index: 1035;
+}
+
 /* nice effects on the \`New!\`-Badge, but only if user allows animations */
 @media (prefers-reduced-motion: no-preference) {
     .${newSettingBadgeClass} {

--- a/redesign.user.js
+++ b/redesign.user.js
@@ -2552,9 +2552,9 @@ form .fitem label .${newSettingBadgeClass} {
         content: " ";
         position: absolute;
         background: linear-gradient(to top, gold 50%, white 100%);
-        --height: 1lh;
-        height: var(--height);
-        width: calc(var(--height) * 11 / 18);
+         --width: 10ch;
+        width: var(--width);
+        height: calc(var(--width) * 18 / 11);
         /* stolen from https://css-shape.com/sparkle/ */
         mask: radial-gradient(#0000 71%, #000 72%) 10000% 10000%/99.5% 99.5%;
         transform: translate(-50%, -50%);
@@ -2585,7 +2585,7 @@ form .fitem label .${newSettingBadgeClass} {
         scale: 0;
     }
     100% { /* 1s => 1000ms */
-        scale: 1;
+        scale: 10%; /* for better results, we're creating large sparkles (width: 10ch), but to keep them rendered small, max scale is 10% */
     }
 }
 @keyframes ${newSettingBadgeAnimations.sparklePositions} {


### PR DESCRIPTION
This PR closes #152.

# Features
* **settings**: new setting that allows highlighting settings that are new (default: on)
* **settings**: new setting that allows showing a tooltip on settings btn to indicate if there are new settings (default: on)

# Additional / TODO
- [x] show a floating badge if there are unseen settings further down the settings modal
- [x] navbar tooltip has z-index greater than z-index of modal backdrop => needs to be fixed