### PR TITLE
fix(courses/images): Don't apply maxWidth on drag and drop question images (#963)

### DIFF
--- a/src/features/courses/images/maxWidth.scss
+++ b/src/features/courses/images/maxWidth.scss
@@ -1,4 +1,7 @@
 // prevent images from overflowing
-#region-main img:not(.activityicon):not(.icon):not(.img-fluid) {
+#region-main
+    img:not(.activityicon):not(.icon):not(.img-fluid):not(.draghome):not(
+        .droppreview
+    ) {
     max-width: 100%;
 }


### PR DESCRIPTION
Placed images in a question of type ddimageortext have class "draghome" in the question itself and "droppreview" in the question editor. In both cases the width of the image is set explicity, and the parent is considered to have zero width. Thus setting `max-width: 100%` causes them to collapse to zero width too.

Fixes: #963